### PR TITLE
Fix two-element majority detection and add tests

### DIFF
--- a/Week-4/majority.py
+++ b/Week-4/majority.py
@@ -1,13 +1,23 @@
 # python3
-n = int(input())
-seq = [int(i) for i in input().split()]
+
+"""Majority element detection using divide-and-conquer."""
 
 
 def divide_func(seq, l, r):
-    if l+1==r:
+    """Return the majority element in ``seq[l:r]`` or ``-1`` if none exists.
+
+    The original implementation returned ``seq[l]`` when ``r - l == 2`` which
+    incorrectly assumed that the first of the two elements was the majority.
+    For a sequence such as ``[1, 2]`` this resulted in reporting a majority
+    element even though none exists.  The function now correctly handles
+    two-element slices by checking whether both elements are equal.
+    """
+    if l + 1 == r:
+        # Only one element – it is trivially the majority
         return seq[l]
-    elif l+2==r:
-        return seq[l]
+    elif l + 2 == r:
+        # Two elements – return the value only if both are the same
+        return seq[l] if seq[l] == seq[l + 1] else -1
     m = (l+r)//2
     left = divide_func(seq, l, m)
     right = divide_func(seq, m, r)
@@ -22,8 +32,12 @@ def divide_func(seq, l, r):
         return left
     elif c2>(r-l)//2 and right != -1:
         return right
-    else: 
+    else:
         return -1
 
-print(int(divide_func(seq, 0, n) != -1))
+
+if __name__ == "__main__":
+    n = int(input())
+    seq = [int(i) for i in input().split()]
+    print(int(divide_func(seq, 0, n) != -1))
 

--- a/test_majority.py
+++ b/test_majority.py
@@ -1,0 +1,21 @@
+import importlib.util
+from pathlib import Path
+
+# Dynamically load the majority module from the Week-4 directory
+module_path = Path(__file__).resolve().parent / 'Week-4' / 'majority.py'
+spec = importlib.util.spec_from_file_location('majority', module_path)
+majority = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(majority)
+
+
+def has_majority(seq):
+    return majority.divide_func(seq, 0, len(seq)) != -1
+
+
+def test_no_majority_two_elements():
+    assert has_majority([1, 2]) is False
+
+
+def test_majority_two_elements():
+    assert has_majority([2, 2]) is True
+


### PR DESCRIPTION
## Summary
- correct divide-and-conquer majority detection for two-element slices
- wrap CLI code in `if __name__ == '__main__'`
- add regression tests for majority algorithm

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898ffd565d483229f5988874519e5df